### PR TITLE
fix: Add required 'Host' for proxy support

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -186,7 +186,9 @@ var instagram = function(spec, my) {
         method: method,
         path: '/v1' + path + (method === 'GET' || method === 'DELETE' ? '?' + query.stringify(params) : ''),
         agent: my.agent,
-        headers: {}
+        headers: {
+          Host: url.parse(my.host).hostname,
+        }
       };
 
       // oauth and oembed calls don't use /v1


### PR DESCRIPTION
Hi,
i found a problem using the lib with a proxy because of the missing required `Host` header.

**Edit**:
Sorry wrong repo :(
